### PR TITLE
feat(oauth): Enable the configuration of oauth scopes via the values 

### DIFF
--- a/helm-charts/kubero/templates/deployment.yaml
+++ b/helm-charts/kubero/templates/deployment.yaml
@@ -169,6 +169,10 @@ spec:
               value: {{ .Values.kubero.auth.oauth2.tokenUrl | quote }}
             - name: OAUTH2_CLIENT_CALLBACKURL
               value: {{ .Values.kubero.auth.oauth2.callbackUrl | quote }}
+            {{- if .Values.kubero.auth.oauth2.scope }}
+            - name: OAUTH2_CLIENT_SCOPE
+              value: {{ .Values.kubero.auth.oauth2.scope | quote }}
+            {{- end }}
             {{- end }}
             - name: DEBUG
               value: "{{ .Values.kubero.debug }}"

--- a/helm-charts/kubero/values.yaml
+++ b/helm-charts/kubero/values.yaml
@@ -112,6 +112,7 @@ kubero:
       tokenUrl: ""
       secret: ""
       callbackUrl: ""
+      scope: "" # space seperated list of scopes
   auditLogs:
     enabled: false
     storageClassName:


### PR DESCRIPTION
The helm chart counterpart to my [oauth2 scopes PR for kubero](https://github.com/kubero-dev/kubero/pull/283).

The goal is to make oauth2 scopes configurable via the chart values.
I described the idea behind custom oauth2 scopes in my kubero PR.