### PR TITLE
Typo for OAUTH2 in k8s template

### DIFF
--- a/helm-charts/kubero/templates/deployment.yaml
+++ b/helm-charts/kubero/templates/deployment.yaml
@@ -169,7 +169,7 @@ spec:
                 secretKeyRef:
                   name: kubero-secrets
                   key: OAUTH2_CLIENT_SECRET
-            - name: OAUTO2_CLIENT_NAME
+            - name: OAUTH2_CLIENT_NAME
               value: {{ .Values.kubero.auth.oauth2.name | quote }}
             - name: OAUTH2_CLIENT_ID
               {{- if .Values.kubero.auth.oauth2.id }}
@@ -180,9 +180,9 @@ spec:
                   name: kubero-secrets
                   key: OAUTH2_CLIENT_ID
               {{- end }}
-            - name: OAUTO2_CLIENT_AUTH_URL
+            - name: OAUTH2_CLIENT_AUTH_URL
               value: {{ .Values.kubero.auth.oauth2.authUrl | quote }}
-            - name: OAUTO2_CLIENT_TOKEN_URL
+            - name: OAUTH2_CLIENT_TOKEN_URL
               value: {{ .Values.kubero.auth.oauth2.tokenUrl | quote }}
             - name: OAUTH2_CLIENT_CALLBACKURL
               value: {{ .Values.kubero.auth.oauth2.callbackUrl | quote }}


### PR DESCRIPTION
A few env variables are prefixed by OAUTO2 instead of OAUTH2