### PR TITLE
Option to set resource limits for the init containers

### DIFF
--- a/helm-charts/kuberoapp/templates/deployment-web.yaml
+++ b/helm-charts/kuberoapp/templates/deployment-web.yaml
@@ -81,6 +81,10 @@ spec:
               readOnly: true
             - mountPath: /app
               name: app-storage
+          {{- with .Values.image.fetch.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: {{ .Chart.Name }}-builder
           securityContext:
             {{- toYaml .Values.image.build.securityContext | nindent 12 }}
@@ -95,12 +99,16 @@ spec:
             - mountPath: {{ .mountPath }}
               name: {{ .name }}
             {{- end }}
+          {{- with .Values.image.build.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-web
           securityContext:
             {{- toYaml .Values.image.run.securityContext | nindent 12 }}
-          {{- if or (eq .Values.deploymentstrategy "docker") (or (eq .Values.buildstrategy "dockerfile") (eq .Values.buildstrategy "nixpacks") (eq .Values.buildstrategy "buildpacks") (eq .Values.buildstrategy "external")) }}
+          {{- if or (eq .Values.deploymentstrategy "docker") (or (eq .Values.buildstrategy "dockerfile") (eq .Values.buildstrategy "nixpacks") (eq .Values.buildstrategy "buildpacks") (eq .Values.build[...]) }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
           {{- if .Values.image.command }}
           command:


### PR DESCRIPTION
I've added this because I was experiencing some issues with a builder using to much resources and thus getting killed by the system.

I don't know if this wil fix it. but it can prevent the build pods from using all the CPU/memory 