### PR TITLE
fix: replace discontinued kube-rbac-proxy image

### DIFF
--- a/bundle/manifests/kubero-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubero-operator.clusterserviceversion.yaml
@@ -2464,7 +2464,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+                image: quay.io/brancz/kube-rbac-proxy:v0.21.2
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.2
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2427,7 +2427,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.2
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
The `gcr.io/kubebuilder/kube-rbac-proxy` image was removed upstream. Use `quay.io/brancz/kube-rbac-proxy:v0.21.2` so operator installs succeed.

Fixes kubero-dev/kubero#735 and kubero-dev/kubero#744